### PR TITLE
Test publishing twice

### DIFF
--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSpec.scala
@@ -75,6 +75,11 @@ class MqttSpec
       val pubAck = PubAck(PacketId(1))
       val pubAckBytes = pubAck.encode(ByteString.newBuilder).result()
 
+      val publish2 = Publish("some-topic", ByteString("some-payload"))
+      val publish2Bytes = publish2.encode(ByteString.newBuilder, Some(PacketId(2))).result()
+      val pubAck2 = PubAck(PacketId(2))
+      val pubAck2Bytes = pubAck2.encode(ByteString.newBuilder).result()
+
       client.offer(Command(connect))
 
       server.expectMsg(connectBytes)
@@ -90,7 +95,15 @@ class MqttSpec
       server.expectMsg(publishBytes)
       server.reply(pubAckBytes)
 
-      result.futureValue shouldBe List(Right(Event(connAck)), Right(Event(subAck)), Right(Event(pubAck)))
+      client.offer(Command(publish2))
+
+      server.expectMsg(publish2Bytes)
+      server.reply(pubAck2Bytes)
+
+      result.futureValue shouldBe List(Right(Event(connAck)),
+                                       Right(Event(subAck)),
+                                       Right(Event(pubAck)),
+                                       Right(Event(pubAck2)))
     }
 
     "Connect and carry through an object to ConnAck" in {


### PR DESCRIPTION
This fails with:

```
[info] MqttSpec:
[info] MQTT connector
[info] - should flow through a client session *** FAILED *** (3 seconds, 110 milliseconds)
[info]   java.lang.AssertionError: assertion failed: timeout (3 seconds) during expectMsg while waiting for ByteString(50, 26, 0, 10, 115, 111, 109, 101, 45, 116, 111, 112, 105, 99, 0, 2, 115, 111, 109, 101, 45, 112, 97, 121, 108, 111, 97, 100)
[info]   at scala.Predef$.assert(Predef.scala:219)
[info]   at akka.testkit.TestKitBase.expectMsg_internal(TestKit.scala:402)
[info]   at akka.testkit.TestKitBase.expectMsg(TestKit.scala:379)
[info]   at akka.testkit.TestKitBase.expectMsg$(TestKit.scala:379)
[info]   at akka.testkit.TestKit.expectMsg(TestKit.scala:896)
[info]   at docs.scaladsl.MqttSpec.$anonfun$new$2(MqttSpec.scala:100)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.WordSpecLike$$anon$1.apply(WordSpecLike.scala:1078)
[info]   at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
[info]   at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
[info]   at docs.scaladsl.MqttSpec.withFixture(MqttSpec.scala:22)
[info]   at org.scalatest.WordSpecLike.invokeWithFixture$1(WordSpecLike.scala:1076)
[info]   at org.scalatest.WordSpecLike.$anonfun$runTest$1(WordSpecLike.scala:1088)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
[info]   at org.scalatest.WordSpecLike.runTest(WordSpecLike.scala:1088)
[info]   at org.scalatest.WordSpecLike.runTest$(WordSpecLike.scala:1070)
[info]   at docs.scaladsl.MqttSpec.runTest(MqttSpec.scala:22)
[info]   at org.scalatest.WordSpecLike.$anonfun$runTests$1(WordSpecLike.scala:1147)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:396)
[info]   at scala.collection.immutable.List.foreach(List.scala:388)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:373)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:410)
[info]   at scala.collection.immutable.List.foreach(List.scala:388)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:379)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
[info]   at org.scalatest.WordSpecLike.runTests(WordSpecLike.scala:1147)
[info]   at org.scalatest.WordSpecLike.runTests$(WordSpecLike.scala:1146)
[info]   at docs.scaladsl.MqttSpec.runTests(MqttSpec.scala:22)
[info]   at org.scalatest.Suite.run(Suite.scala:1147)
[info]   at org.scalatest.Suite.run$(Suite.scala:1129)
[info]   at docs.scaladsl.MqttSpec.org$scalatest$WordSpecLike$$super$run(MqttSpec.scala:22)
[info]   at org.scalatest.WordSpecLike.$anonfun$run$1(WordSpecLike.scala:1192)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
[info]   at org.scalatest.WordSpecLike.run(WordSpecLike.scala:1192)
[info]   at org.scalatest.WordSpecLike.run$(WordSpecLike.scala:1190)
[info]   at docs.scaladsl.MqttSpec.org$scalatest$BeforeAndAfterAll$$super$run(MqttSpec.scala:22)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]   at docs.scaladsl.MqttSpec.run(MqttSpec.scala:22)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:507)
[info]   at sbt.TestRunner.runTest$1(TestFramework.scala:113)
[info]   at sbt.TestRunner.run(TestFramework.scala:124)
[info]   at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.$anonfun$apply$1(TestFramework.scala:282)
[info]   at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:246)
[info]   at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:282)
[info]   at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:282)
[info]   at sbt.TestFunction.apply(TestFramework.scala:294)
[info]   at sbt.Tests$.$anonfun$toTask$1(Tests.scala:309)
[info]   at sbt.std.Transform$$anon$3.$anonfun$apply$2(System.scala:46)
[info]   at sbt.std.Transform$$anon$4.work(System.scala:67)
[info]   at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[info]   at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[info]   at sbt.Execute.work(Execute.scala:278)
[info]   at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[info]   at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[info]   at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[info]   at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info]   at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[info]   at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[info]   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[info]   at java.lang.Thread.run(Thread.java:748)
[info] - should Connect and carry through an object to ConnAck (16 milliseconds)
[info] - should disconnect when connected (16 milliseconds)
[info] - should receive a QoS 0 publication from a subscribed topic (76 milliseconds)
[info] - should receive a QoS 1 publication from a subscribed topic and ack it (93 milliseconds)
[info] - should receive a QoS 2 publication from a subscribed topic and rec and comp it (149 milliseconds)
[info] - should publish with a QoS of 0 (16 milliseconds)
[info] - should publish and carry through an object to pubAck (77 milliseconds)
[info] ScalaTest
[info] Run completed in 4 seconds, 54 milliseconds.
[info] Total number of tests run: 69
[info] Suites: completed 5, aborted 0
[info] Tests: succeeded 68, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed: Total 70, Failed 1, Errors 0, Passed 69
[error] Failed tests:
[error] 	docs.scaladsl.MqttSpec
[error] (Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 8 s, completed Oct 3, 2018 2:48:40 PM

```

Debugging shows that the second Publish is being ignored in this code:

```scala
      case (context, PublishReceivedLocally(publish, publishData, remote)) =>
        val producerName = ProducerNamePrefix + encodeTopicName(publish.topicName)
        context.child(producerName) match {
          case None =>
            context.spawn(Producer(publish.flags, publishData, remote, data.producerPacketRouter, data.settings),
                          producerName)
          case _: Some[_] =>
            // Ignored for existing subscriptions
        }
```